### PR TITLE
Fix Faraday authentication bug 

### DIFF
--- a/lib/mediumite/client.rb
+++ b/lib/mediumite/client.rb
@@ -18,8 +18,8 @@ module Mediumite
 
     def agent
       @agent ||= Sawyer::Agent.new("https://api.medium.com/v1") do |http|
+        http.request :authorization, "Bearer", token
         http.headers[:content_type] = "application/json"
-        http.authorization "Bearer", token
       end
     end
 

--- a/mediumite.gemspec
+++ b/mediumite.gemspec
@@ -18,10 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sawyer"
+  spec.add_dependency "sawyer", "~> 0.9.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "webmock", "~> 3.17.1"
 end

--- a/spec/mediumite/client_spec.rb
+++ b/spec/mediumite/client_spec.rb
@@ -1,18 +1,76 @@
 require "spec_helper"
 
 describe Mediumite::Client do
+  let(:client) { Mediumite::Client.new(token: "access-token") }
+
   describe "instantiation" do
     it "masks token on inspect" do
-      client = Mediumite::Client.new(token: "abcdefghijklmnopqrstuvwxyz")
       inspected = client.inspect
-      expect(inspected).not_to include("abcdefghijklmnopqrstuvwxyz")
+      expect(inspected).not_to include("access-token")
     end
   end
 
   describe "#token" do
     it "returns given token" do
-      client = Mediumite::Client.new(token: "token")
-      expect(client.token).to eq "token"
+      expect(client.token).to eq "access-token"
     end
   end
+
+  describe "#create_post" do
+    it "sends the expected params to Medium blog" do
+      post = Mediumite::Post.new(
+        title: "Test post title",
+        body: "# Test post body",
+        publication_id: "publication-id"
+      )
+      stub = stubbed_post_create(title: "Test post title", publication_id: "publication-id")
+
+      response = client.create_post(post)
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  private
+
+    def stubbed_post_create(title: "Test post title",
+                            body: "# Test post body",
+                            publication_id: "publication-id",
+                            access_token: "access-token")
+      response_headers = { "Content-Type" => "application/json" }
+
+      stub_request(:post, "https://api.medium.com/v1/publications/#{publication_id}/posts").
+        with(
+          body: {
+            title: title,
+            contentFormat: "markdown",
+            content: body,
+            canonicalUrl: nil,
+            tags: nil,
+            publishStatus: "draft"
+          }.to_json,
+          headers: {
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer #{access_token}",
+            "Content-Type" => "application/json"
+          }
+        ).
+        to_return(status: 200, body: <<~JSON, headers: response_headers)
+          {
+            "data": {
+              "id": "e6f36a",
+              "title": "Test post title",
+              "authorId": "#{Random.hash}",
+              "tags": [],
+              "url": "https://medium.com/@mediumuser/test-post-title-e6f36a",
+              "canonicalUrl": "http://example.com/posts/test-post-title",
+              "publishStatus": "public",
+              "publishedAt": #{Time.now.to_i},
+              "license": "all-rights-reserved",
+              "licenseUrl": "https://medium.com/policy/9db0094a1e0f"
+            }
+          }
+        JSON
+    end
 end

--- a/spec/mediumite/client_spec.rb
+++ b/spec/mediumite/client_spec.rb
@@ -23,7 +23,7 @@ describe Mediumite::Client do
         body: "# Test post body",
         publication_id: "publication-id"
       )
-      stub = stubbed_post_create(title: "Test post title", publication_id: "publication-id")
+      stub = stubbed_post_create
 
       response = client.create_post(post)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "mediumite"
+require 'webmock/rspec'
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
## What

Fixes a bug caused by a change in the Faraday authentication API.

Adds specs to ensure desired behaviour exists.

## Why

This was breaking, and preventing users from creating posts.

## How

Use the [Faraday::Request::Authorization](https://github.com/lostisland/faraday/blob/main/docs/middleware/request/authentication.md) middleware in client requests.
